### PR TITLE
feat: Add option to generate modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Installation](#installation)
   - [CLI Usage](#cli-usage)
     - [Specifying a Destination Directory](#specifying-a-destination-directory)
+    - [Create as an ES module](#create-as-an-es-module)
     - [Options](#options)
   - [API Usage](#api-usage)
   - [License](#license)
@@ -56,9 +57,17 @@ $ vjslang foo/bar.json --dir baz
 
 The directory will be created if it does not exist. If creation fails, `vjslang` will fall back to its default behavior.
 
+### Create as an ES module
+
+The `--asModule`/`-m` option creates an .mjs moduel file which can be directly imported.
+
+```sh
+$ vjslang foo/bar.json --dir baz --asModule
+```
+
 ### Options
 
-The `--dir`/`-d` option is the most interesting/useful. For full option documentation refer to:
+The `--dir`/`-d` and `--asModule`/`-m` options are the most interesting/useful. For full option documentation refer to:
 
 ```sh
 $ vjslang --help
@@ -71,7 +80,9 @@ There is a very simple programmatic API that can be used in your own programs. I
 ```js
 import convert from 'videojs-languages';
 
-convert(['foo/bar.json', 'baz/*.json'], 'langs');
+const asModule = true;
+
+convert(['foo/bar.json', 'baz/*.json'], 'langs', asModule);
 ```
 
 ## License

--- a/src/api.js
+++ b/src/api.js
@@ -21,12 +21,15 @@ const {
  *         to create it. If not provided or creation fails, converted .js
  *         files will be placed alongside their .json sources.
  *
+ * @param  {boolean} [asModule]
+ *         Create as an ES module
+ *
  * @return {Object}
  *         An object with `srces` and `dests` arrays.
  */
-const convert = (patterns, dir) => {
+const convert = (patterns, dir, asModule) => {
   const srces = findSources(normalizePatterns(patterns));
-  const dests = processSources(srces, normalizeDir(dir));
+  const dests = processSources(srces, normalizeDir(dir), asModule);
 
   return {srces, dests};
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,13 +15,18 @@ cli.parse({
       'files will be placed alongside their .json sources.'
     ].join(' '),
     'string'
+  ],
+  asModule: [
+    'm',
+    'Create a module for ES import.',
+    'bool'
   ]
 });
 
 cli.main(function(args, options) {
   this.debug(`args: ${JSON.stringify(args)}, options: ${JSON.stringify(options)}`);
 
-  const result = convert(args, options.dir);
+  const result = convert(args, options.dir, options.asModule);
   const conversions = result.srces.map((s, i) => `${s} => ${result.dests[i]}`);
   const sep = '\n  ';
 

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -68,6 +68,7 @@ suite('lib', () => {
       destination('/path/to/foo.json', '/other/path'),
       '/other/path/foo.js'
     );
+    assert.strictEqual(destination('/path/to/foo.json', null, 'mjs'), '/path/to/foo.mjs');
   });
 
   test('findSources', () => {
@@ -103,6 +104,32 @@ suite('lib', () => {
           "y": true
         });
       `
+    );
+  });
+
+  test('processSourcesAsModules', () => {
+    const srces = processSources(findSources(['a/**/*']), normalizeDir('c'), true);
+
+    assert.sameMembers(srces, ['c/x.mjs', 'c/y.mjs']);
+
+    assert.strictEqual(
+      fs.readFileSync('c/x.mjs', 'utf8'),
+      tsmlb`
+        import videojs from "video.js";
+        import x from "../a/b/x.json";
+
+        videojs.addLanguage('x', x);
+      ` + '\n'
+    );
+
+    assert.strictEqual(
+      fs.readFileSync('c/y.mjs', 'utf8'),
+      tsmlb`
+        import videojs from "video.js";
+        import y from "../a/b/y.json";
+
+        videojs.addLanguage('y', y);
+      ` + '\n'
     );
   });
 });


### PR DESCRIPTION
Adds an option to create modules with an mjs extensions, whic then could simply be imported, e.g.

```
import "package/es/uk.mjs";
```
